### PR TITLE
Add property and recovery

### DIFF
--- a/src/modules/database/Database.ts
+++ b/src/modules/database/Database.ts
@@ -9,6 +9,7 @@ import { DataSource } from "typeorm";
 import { createDatabase, } from 'typeorm-extension';
 import pg from "pg"
 import { PostgresDriver } from "typeorm/driver/postgres/PostgresDriver";
+import { PropertyDatabase } from "./property/PropertyDatabase";
 
 export type DatabaseStartOptions = {
     name: string
@@ -27,6 +28,7 @@ export class Database {
     transactions = new TransactionDatabase(this)
     items = new ItemsDatabase(this)
     notifications = new NotificationsDatabase(this)
+    properties = new PropertyDatabase(this)
 
     // async call<ReturnData extends Record<string, any>>(name: string, args: unknown[]) {
     //     const { rows, fields } = await this._pool!.query({

--- a/src/modules/database/QueryResults.ts
+++ b/src/modules/database/QueryResults.ts
@@ -136,4 +136,32 @@ export namespace QueryResults {
             }[]
         } | { code : 1 }
     }
+
+    export namespace Property {
+        export type List = {
+            code: 0,
+            properties: {
+                uuid: string,
+                name: string,
+                description: string
+                status: number,
+                property: string,
+            }[]
+        } | { code: 1 }
+
+        export type Register = { code: 0 | 1 }
+        export type Unregister = { code: 0 | 1 }
+        export type Update = { code: 0 | 1 }
+
+        export type Resolve = {
+            code: 0,
+            properties: {
+                uuid: string,
+                name: string,
+                description: string
+                status: number,
+                property: string,
+            }[]
+        } | { code : 1 }
+    }
 }

--- a/src/modules/database/QueryResults.ts
+++ b/src/modules/database/QueryResults.ts
@@ -155,13 +155,13 @@ export namespace QueryResults {
 
         export type Resolve = {
             code: 0,
-            properties: {
+            data: {
                 uuid: string,
                 name: string,
                 description: string
                 status: number,
                 property: string,
-            }[]
+            }
         } | { code : 1 }
     }
 }

--- a/src/modules/database/QueryResults.ts
+++ b/src/modules/database/QueryResults.ts
@@ -145,6 +145,12 @@ export namespace QueryResults {
                 name: string,
                 description: string
                 status: number,
+                recovery: {
+                    uuid: string
+                    surrendered: boolean
+                    message?: string
+                    timestamp: number
+                } | null
                 property: string,
             }[]
         } | { code: 1 }
@@ -160,6 +166,12 @@ export namespace QueryResults {
                 name: string,
                 description: string
                 status: number,
+                recovery: {
+                    uuid: string
+                    surrendered: boolean
+                    message?: string
+                    timestamp: number
+                } | null
                 property: string,
             }
         } | { code : 1 }

--- a/src/modules/database/Source.ts
+++ b/src/modules/database/Source.ts
@@ -4,6 +4,7 @@ import { Bank } from "modules/database/entities/Bank"
 import { Items } from "modules/database/entities/Items"
 import { Transactions } from "modules/database/entities/Transactions"
 import { Notifications } from "modules/database/entities/Notifications"
+import { Property } from "modules/database/entities/Property"
 
 export default {
     type: "postgres",
@@ -14,7 +15,7 @@ export default {
     database: process.env.DB_NAME,
     synchronize: true,
     logging: true,
-    entities: [Users, Bank, Items, Transactions, Notifications],
+    entities: [Users, Bank, Items, Transactions, Notifications, Property],
     migrations: [],
     subscribers: [],
     entitySkipConstructor: true

--- a/src/modules/database/entities/Property.ts
+++ b/src/modules/database/entities/Property.ts
@@ -19,15 +19,24 @@ export class Property {
     
     @Column({ type: "integer", default: 0 })
     status: number
+
+    @Column({ type: "json", array: false, nullable: true })
+    recovery?: {
+        uuid: string
+        surrendered: boolean
+        message?: string
+        timestamp: number
+    }
     
     @Column({ type: "uuid", generated: true })
     property: string
 
-    constructor(data: { uuid: string, name: string, description: string, status: number, property: string }) {
+    constructor(data: { uuid: string, name: string, description: string, status: number, recovery: { uuid: string, surrendered: boolean, message?: string, timestamp: number }, property: string }) {
         this.uuid = data.uuid
         this.name = data.name
         this.description = data.description
         this.status = data.status
+        this.recovery = data.recovery
         this.property = data.property
     }
 }

--- a/src/modules/database/entities/Property.ts
+++ b/src/modules/database/entities/Property.ts
@@ -28,7 +28,7 @@ export class Property {
         timestamp: number
     }
     
-    @Column({ type: "uuid", generated: true })
+    @Column({ type: "uuid", generated: "uuid" })
     property: string
 
     constructor(data: { uuid: string, name: string, description: string, status: number, recovery: { uuid: string, surrendered: boolean, message?: string, timestamp: number }, property: string }) {

--- a/src/modules/database/entities/Property.ts
+++ b/src/modules/database/entities/Property.ts
@@ -11,23 +11,23 @@ export class Property {
     @JoinColumn({ name: "uuid" })
     uuid: string
     
-    @Column({ type: "uuid" })
-    property: string
-
-    @Column({ type: "integer" })
-    status: number
-
     @Column({ type: "text" })
     name: string
-
+    
     @Column({ type: "text" })
     description: string
+    
+    @Column({ type: "integer", default: 0 })
+    status: number
+    
+    @Column({ type: "uuid", generated: true })
+    property: string
 
-    constructor(data: { uuid: string, property: string, status: number, name: string, description: string }) {
+    constructor(data: { uuid: string, name: string, description: string, status: number, property: string }) {
         this.uuid = data.uuid
-        this.property = data.property
-        this.status = data.status
         this.name = data.name
         this.description = data.description
+        this.status = data.status
+        this.property = data.property
     }
 }

--- a/src/modules/database/entities/Property.ts
+++ b/src/modules/database/entities/Property.ts
@@ -1,0 +1,33 @@
+import { Entity, Column, PrimaryColumn, JoinColumn, ManyToOne } from "typeorm"
+import { Users } from "./Users"
+
+@Entity()
+export class Property {
+    @PrimaryColumn("uuid")
+    @ManyToOne(() => Users, (user) => user.uuid,  {
+        onUpdate: "CASCADE",
+        onDelete: "CASCADE"
+    })
+    @JoinColumn({ name: "uuid" })
+    uuid: string
+    
+    @Column({ type: "uuid" })
+    property: string
+
+    @Column({ type: "integer" })
+    status: number
+
+    @Column({ type: "text" })
+    name: string
+
+    @Column({ type: "text" })
+    description: string
+
+    constructor(data: { uuid: string, property: string, status: number, name: string, description: string }) {
+        this.uuid = data.uuid
+        this.property = data.property
+        this.status = data.status
+        this.name = data.name
+        this.description = data.description
+    }
+}

--- a/src/modules/database/entities/Property.ts
+++ b/src/modules/database/entities/Property.ts
@@ -21,15 +21,15 @@ export class Property {
     status: number
 
     @Column({ type: "json", array: false, nullable: true })
-    recovery?: {
+    recovery: {
         uuid: string
         surrendered: boolean
         message?: string
         timestamp: number
-    }
+    } | null
     
     @Column({ type: "uuid", generated: "uuid" })
-    property: string
+    property: string 
 
     constructor(data: { uuid: string, name: string, description: string, status: number, recovery: { uuid: string, surrendered: boolean, message?: string, timestamp: number }, property: string }) {
         this.uuid = data.uuid

--- a/src/modules/database/property/PropertyDatabase.ts
+++ b/src/modules/database/property/PropertyDatabase.ts
@@ -9,15 +9,15 @@ export class PropertyDatabase {
     source: DataSource
     repository: Repository<Property>
 
-    async list() {
-        return (this.repository.find()
+    async list(uuid: string) {
+        return (this.repository.findBy({ uuid })
             .then((properties) => { return { code: 0, properties } })
             .catch(() => { return { code: 1 } })
         ) as Promise<QueryResults.Property.List>
     }
 
-    async register(uuid: string, name: string, description: string, status: number, property: string ) {
-        return (this.repository.insert({ uuid, name, description, status, property })
+    async register(uuid: string, name: string, description: string) {
+        return (this.repository.insert({ uuid, name, description })
             .then(() => { return { code: 0 } })
             .catch(() => { return { code: 1 } })
         ) as Promise<QueryResults.Property.Register>
@@ -37,8 +37,8 @@ export class PropertyDatabase {
         ) as Promise<QueryResults.Property.Update>
     }
 
-    async resolve(uuid: string) {
-        return (this.repository.findBy({ uuid })
+    async resolve(uuid: string, property: string) {
+        return (this.repository.findBy({ uuid, property })
             .then((properties) => { return { code: 0, properties } })
             .catch(() => { return { code: 1 } })
         ) as Promise<QueryResults.Property.Resolve>

--- a/src/modules/database/property/PropertyDatabase.ts
+++ b/src/modules/database/property/PropertyDatabase.ts
@@ -30,8 +30,8 @@ export class PropertyDatabase {
         ) as Promise<QueryResults.Property.Unregister>
     }
 
-    async update(uuid: string, property: string, status: number, recovery?: { uuid: string, surrendered: boolean, message?: string, timestamp: number } | false) {
-        return (this.repository.update({ uuid, property }, recovery == null && recovery !== false ? { status, recovery } : { status })
+    async update(uuid: string, property: string, status: number, recovery?: { uuid: string, surrendered: boolean, message?: string, timestamp: number } | null) {
+        return (this.repository.update({ uuid, property }, { status, recovery })
             .then(results => { return { code: results.affected ? 0 : 1 } })
             .catch(() => { return { code: 1 } })
         ) as Promise<QueryResults.Property.Update>

--- a/src/modules/database/property/PropertyDatabase.ts
+++ b/src/modules/database/property/PropertyDatabase.ts
@@ -30,15 +30,15 @@ export class PropertyDatabase {
         ) as Promise<QueryResults.Property.Unregister>
     }
 
-    async update(uuid: string, property: string, status: number) {
-        return (this.repository.update({ uuid, property }, { status })
+    async update(uuid: string, property: string, status: number, recovery?: { uuid: string, surrendered: boolean, message?: string, timestamp: number }) {
+        return (this.repository.update({ uuid, property }, recovery ? { status, recovery } : { status })
             .then(results => { return { code: results.affected ? 0 : 1 } })
             .catch(() => { return { code: 1 } })
         ) as Promise<QueryResults.Property.Update>
     }
 
-    async resolve(uuid: string, property: string) {
-        return (this.repository.findOneByOrFail({ uuid, property })
+    async resolve(property: string) {
+        return (this.repository.findOneByOrFail({ property })
             .then((data) => { return { code: 0, data } })
             .catch(() => { return { code: 1 } })
         ) as Promise<QueryResults.Property.Resolve>

--- a/src/modules/database/property/PropertyDatabase.ts
+++ b/src/modules/database/property/PropertyDatabase.ts
@@ -38,8 +38,8 @@ export class PropertyDatabase {
     }
 
     async resolve(uuid: string, property: string) {
-        return (this.repository.findBy({ uuid, property })
-            .then((properties) => { return { code: 0, properties } })
+        return (this.repository.findOneByOrFail({ uuid, property })
+            .then((data) => { return { code: 0, data } })
             .catch(() => { return { code: 1 } })
         ) as Promise<QueryResults.Property.Resolve>
     }

--- a/src/modules/database/property/PropertyDatabase.ts
+++ b/src/modules/database/property/PropertyDatabase.ts
@@ -30,8 +30,8 @@ export class PropertyDatabase {
         ) as Promise<QueryResults.Property.Unregister>
     }
 
-    async update(uuid: string, property: string, status: number, recovery?: { uuid: string, surrendered: boolean, message?: string, timestamp: number }) {
-        return (this.repository.update({ uuid, property }, recovery ? { status, recovery } : { status })
+    async update(uuid: string, property: string, status: number, recovery?: { uuid: string, surrendered: boolean, message?: string, timestamp: number } | false) {
+        return (this.repository.update({ uuid, property }, recovery == null && recovery !== false ? { status, recovery } : { status })
             .then(results => { return { code: results.affected ? 0 : 1 } })
             .catch(() => { return { code: 1 } })
         ) as Promise<QueryResults.Property.Update>

--- a/src/modules/database/property/PropertyDatabase.ts
+++ b/src/modules/database/property/PropertyDatabase.ts
@@ -1,0 +1,52 @@
+import { Database } from "modules/database/Database"
+import { Property } from "modules/database/entities/Property"
+import { QueryResults } from "modules/database/QueryResults"
+
+import { DataSource, Repository } from "typeorm"
+
+export class PropertyDatabase {
+    database: Database
+    source: DataSource
+    repository: Repository<Property>
+
+    async list() {
+        return (this.repository.find()
+            .then((properties) => { return { code: 0, properties } })
+            .catch(() => { return { code: 1 } })
+        ) as Promise<QueryResults.Property.List>
+    }
+
+    async register(uuid: string, name: string, description: string, status: number, property: string ) {
+        return (this.repository.insert({ uuid, name, description, status, property })
+            .then(() => { return { code: 0 } })
+            .catch(() => { return { code: 1 } })
+        ) as Promise<QueryResults.Property.Register>
+    }
+
+    async unregister(uuid: string, property: string) {
+        return (this.repository.delete({ uuid, property })
+            .then(() => { return { code: 0 } })
+            .catch(() => { return { code: 1 } })
+        ) as Promise<QueryResults.Property.Unregister>
+    }
+
+    async update(uuid: string, property: string, status: number) {
+        return (this.repository.update({ uuid, property }, { status })
+            .then(results => { return { code: results.affected ? 0 : 1 } })
+            .catch(() => { return { code: 1 } })
+        ) as Promise<QueryResults.Property.Update>
+    }
+
+    async resolve(uuid: string) {
+        return (this.repository.findBy({ uuid })
+            .then((properties) => { return { code: 0, properties } })
+            .catch(() => { return { code: 1 } })
+        ) as Promise<QueryResults.Property.Resolve>
+    }
+
+    constructor(database: Database) {
+        this.database = database
+        this.source = database.source
+        this.repository = this.source.getRepository(Property)
+    }
+}

--- a/src/modules/server/Server.ts
+++ b/src/modules/server/Server.ts
@@ -4,6 +4,7 @@ import { ItemManager } from "modules/server/items/ItemManager";
 import { MenuManager } from "modules/server/menu/MenuManager";
 import { NotificationManager } from "modules/server/notifications/NotificationManager";
 import { OrderManager } from "modules/server/orders/OrderManager";
+import { PropertyManager } from "modules/server/property/PropertyManager";
 import { TransactionManager } from "modules/server/transactions/TransactionManager";
 import { UserManager } from "modules/server/users/UserManager";
 import { Database } from "modules/database/Database";
@@ -51,6 +52,7 @@ export class Server {
     menu: MenuManager
     notifications: NotificationManager
     orders: OrderManager
+    properties: PropertyManager
     transactions: TransactionManager
 
     async start(options?: ServerStartOptions): Promise<{ ssl: boolean, port: number }> {
@@ -102,6 +104,7 @@ export class Server {
         this.menu = new MenuManager(this.items)
         this.notifications = new NotificationManager(database, { firebase: { account: options.firebase.account } })
         this.orders = new OrderManager(database, this.items)
+        this.properties = new PropertyManager(database)
         this.transactions = new TransactionManager(database)
     }
 }

--- a/src/modules/server/notifications/NotificationManager.ts
+++ b/src/modules/server/notifications/NotificationManager.ts
@@ -15,13 +15,13 @@ export interface Token {
 
 export type NotificationSendOptions = {
     type: "single",
-    data: firebase.messaging.Message
+    message: firebase.messaging.Message
 } | {
     type: "multiple",
-    data: firebase.messaging.Message[]
+    message: firebase.messaging.Message[]
 } | {
     type: "broadcast",
-    data: firebase.messaging.MulticastMessage
+    message: firebase.messaging.MulticastMessage
 }
 
 export class NotificationManager {
@@ -96,12 +96,12 @@ export class NotificationManager {
         let query
 
         switch(options.type) {
-            case "single": query = this.messaging.send(options.data); break
-            case "multiple": query = this.messaging.sendEach(options.data); break
-            case "broadcast": query = this.messaging.sendEachForMulticast(options.data); break
+            case "single": query = this.messaging.send(options.message); break
+            case "multiple": query = this.messaging.sendEach(options.message); break
+            case "broadcast": query = this.messaging.sendEachForMulticast(options.message); break
         }
 
-        query
+        return query
             .then(() => { return { code: 0 } as const })
             .catch(() => { return { code: 1 } as const })
     }

--- a/src/modules/server/property/PropertyManager.ts
+++ b/src/modules/server/property/PropertyManager.ts
@@ -22,7 +22,7 @@ export class PropertyManager {
         return { code: 0 } as const
     }
 
-    async update(uuid: string, property: string, status: number, recovery?: { uuid: string, surrendered: boolean, message?: string, timestamp: number } | false) {
+    async update(uuid: string, property: string, status: number, recovery?: { uuid: string, surrendered: boolean, message?: string, timestamp: number } | null) {
         const query = await this.database.properties.update(uuid, property, status, recovery)
         if (query.code) return { code: 1 } as const
 

--- a/src/modules/server/property/PropertyManager.ts
+++ b/src/modules/server/property/PropertyManager.ts
@@ -22,7 +22,7 @@ export class PropertyManager {
         return { code: 0 } as const
     }
 
-    async update(uuid: string, property: string, status: number, recovery?: { uuid: string, surrendered: boolean, message?: string, timestamp: number }) {
+    async update(uuid: string, property: string, status: number, recovery?: { uuid: string, surrendered: boolean, message?: string, timestamp: number } | false) {
         const query = await this.database.properties.update(uuid, property, status, recovery)
         if (query.code) return { code: 1 } as const
 

--- a/src/modules/server/property/PropertyManager.ts
+++ b/src/modules/server/property/PropertyManager.ts
@@ -22,8 +22,8 @@ export class PropertyManager {
         return { code: 0 } as const
     }
 
-    async update(uuid: string, property: string, status: number) {
-        const query = await this.database.properties.update(uuid, property, status)
+    async update(uuid: string, property: string, status: number, recovery?: { uuid: string, surrendered: boolean, message?: string, timestamp: number }) {
+        const query = await this.database.properties.update(uuid, property, status, recovery)
         if (query.code) return { code: 1 } as const
 
         return { code: 0 } as const
@@ -36,8 +36,8 @@ export class PropertyManager {
         return { code: 0, properties: query.properties } as const
     }
 
-    async resolve(uuid: string, property: string) {
-        const query = await this.database.properties.resolve(uuid, property)
+    async resolve(property: string) {
+        const query = await this.database.properties.resolve(property)
         if (query.code) return { code: 1 } as const
 
         return { code: 0, data: query.data } as const

--- a/src/modules/server/property/PropertyManager.ts
+++ b/src/modules/server/property/PropertyManager.ts
@@ -1,0 +1,49 @@
+import { Database } from 'modules/database/Database'
+
+export interface Token {
+    type: string,
+    token: string
+}
+
+export class PropertyManager {
+    database: Database
+
+    async register(uuid: string, name: string, description: string) {
+        const query = await this.database.properties.register(uuid, name, description)
+        if (query.code) return { code: 1 } as const
+
+        return { code: 0 } as const
+    }
+
+    async unregister(uuid: string, property: string) {
+        const query = await this.database.properties.unregister(uuid, property)
+        if (query.code) return { code: 1 } as const
+
+        return { code: 0 } as const
+    }
+
+    async update(uuid: string, property: string, status: number) {
+        const query = await this.database.properties.update(uuid, property, status)
+        if (query.code) return { code: 1 } as const
+
+        return { code: 0 } as const
+    }
+
+    async list(uuid: string) {
+        const query = await this.database.properties.list(uuid)
+        if (query.code) return { code: 1 } as const
+
+        return { code: 0, properties: query.properties } as const
+    }
+
+    async resolve(uuid: string, property: string) {
+        const query = await this.database.properties.resolve(uuid, property)
+        if (query.code) return { code: 1 } as const
+
+        return { code: 0, data: query.data } as const
+    }
+
+    constructor(database: Database) {
+        this.database = database
+    }
+}

--- a/src/routes/api/v1/property/list.endpoint.ts
+++ b/src/routes/api/v1/property/list.endpoint.ts
@@ -1,0 +1,27 @@
+import { Route, HTTPEndpoint } from "modules/routing/Routing";
+import { Server } from "modules/server/Server"
+import { AuthenticationMiddleware } from "modules/routing/middlewares/auth.middleware";
+
+import { NextFunction, Request, Response } from "express"
+import { z } from "zod"
+
+export default new Route({
+    endpoints: [
+        new HTTPEndpoint({
+            method: "GET",
+            handlers: [
+                AuthenticationMiddleware("HTTP"),
+                async (server: Server, req: Request, res: Response, next: NextFunction) => {
+                    const sessionschema = z.object({ uuid: z.string().uuid() })
+                    const session = sessionschema.safeParse(req.session)
+                    if (!session.success) return res.send({ code: 1 })
+
+                    const query = await server.properties.list(session.data.uuid)
+                    if (query.code) return res.send({ code: 3 })
+
+                    res.send({ code: 0, properties: query.properties })
+                },  
+            ]
+        })
+    ]
+});

--- a/src/routes/api/v1/property/register.endpoint.ts
+++ b/src/routes/api/v1/property/register.endpoint.ts
@@ -1,0 +1,31 @@
+import { Route, HTTPEndpoint } from "modules/routing/Routing";
+import { Server } from "modules/server/Server"
+import { AuthenticationMiddleware } from "modules/routing/middlewares/auth.middleware";
+
+import { NextFunction, Request, Response } from "express"
+import { z } from "zod"
+
+export default new Route({
+    endpoints: [
+        new HTTPEndpoint({
+            method: "POST",
+            handlers: [
+                AuthenticationMiddleware("HTTP"),
+                async (server: Server, req: Request, res: Response, next: NextFunction) => {
+                    const sessionschema = z.object({ uuid: z.string().uuid() })
+                    const session = sessionschema.safeParse(req.session)
+                    if (!session.success) return res.send({ code: 1 })
+
+                    const bodyschema = z.object({ name: z.string(), description: z.string() })
+                    const body = bodyschema.safeParse(req.body)
+                    if (!body.success) return res.send({ code: 2 })
+
+                    const query = await server.properties.register(session.data.uuid, body.data.name, body.data.description)
+                    if (query.code) return res.send({ code: 3 })
+
+                    res.send({ code: 0 })
+                },  
+            ]
+        })
+    ]
+});

--- a/src/routes/api/v1/property/resolve.endpoint.ts
+++ b/src/routes/api/v1/property/resolve.endpoint.ts
@@ -12,11 +12,11 @@ export default new Route({
             handlers: [
                 AuthenticationMiddleware("HTTP"),
                 async (server: Server, req: Request, res: Response, next: NextFunction) => {
-                    const paramschema = z.object({ property: z.string().uuid() })
-                    const params = paramschema.safeParse(req.params)
-                    if (!params.success) return res.send({ code: 1 })
+                    const queryschema = z.object({ property: z.string().uuid() })
+                    const { success, data } = queryschema.safeParse(req.query)
+                    if (!success) return res.send({ code: 1 })
 
-                    const query = await server.properties.resolve(params.data.property)
+                    const query = await server.properties.resolve(data.property)
                     if (query.code) return res.send({ code: 3 })
 
                     res.send({ code: 0, data: query.data })

--- a/src/routes/api/v1/property/resolve.endpoint.ts
+++ b/src/routes/api/v1/property/resolve.endpoint.ts
@@ -1,0 +1,27 @@
+import { Route, HTTPEndpoint } from "modules/routing/Routing";
+import { Server } from "modules/server/Server"
+import { AuthenticationMiddleware } from "modules/routing/middlewares/auth.middleware";
+
+import { NextFunction, Request, Response } from "express"
+import { z } from "zod"
+
+export default new Route({
+    endpoints: [
+        new HTTPEndpoint({
+            method: "GET",
+            handlers: [
+                AuthenticationMiddleware("HTTP"),
+                async (server: Server, req: Request, res: Response, next: NextFunction) => {
+                    const paramschema = z.object({ property: z.string().uuid() })
+                    const params = paramschema.safeParse(req.params)
+                    if (!params.success) return res.send({ code: 1 })
+
+                    const query = await server.properties.resolve(params.data.property)
+                    if (query.code) return res.send({ code: 3 })
+
+                    res.send({ code: 0, data: query.data })
+                },  
+            ]
+        })
+    ]
+});

--- a/src/routes/api/v1/property/unregister.endpoint.ts
+++ b/src/routes/api/v1/property/unregister.endpoint.ts
@@ -1,0 +1,31 @@
+import { Route, HTTPEndpoint } from "modules/routing/Routing";
+import { Server } from "modules/server/Server"
+import { AuthenticationMiddleware } from "modules/routing/middlewares/auth.middleware";
+
+import { NextFunction, Request, Response } from "express"
+import { z } from "zod"
+
+export default new Route({
+    endpoints: [
+        new HTTPEndpoint({
+            method: "POST",
+            handlers: [
+                AuthenticationMiddleware("HTTP"),
+                async (server: Server, req: Request, res: Response, next: NextFunction) => {
+                    const sessionschema = z.object({ uuid: z.string().uuid() })
+                    const session = sessionschema.safeParse(req.session)
+                    if (!session.success) return res.send({ code: 1 })
+
+                    const bodyschema = z.object({ property: z.string().uuid() })
+                    const body = bodyschema.safeParse(req.body)
+                    if (!body.success) return res.send({ code: 2 })
+
+                    const query = await server.properties.unregister(session.data.uuid, body.data.property)
+                    if (query.code) return res.send({ code: 3 })
+
+                    res.send({ code: 0 })
+                },  
+            ]
+        })
+    ]
+});

--- a/src/routes/api/v1/property/update.endpoint.ts
+++ b/src/routes/api/v1/property/update.endpoint.ts
@@ -1,0 +1,46 @@
+import { Route, HTTPEndpoint } from "modules/routing/Routing";
+import { Server } from "modules/server/Server"
+import { AuthenticationMiddleware } from "modules/routing/middlewares/auth.middleware";
+
+import { NextFunction, Request, Response } from "express"
+import { z } from "zod"
+
+export default new Route({
+    endpoints: [
+        new HTTPEndpoint({
+            method: "POST",
+            handlers: [
+                AuthenticationMiddleware("HTTP"),
+                async (server: Server, req: Request, res: Response, next: NextFunction) => {
+                    const sessionschema = z.object({ uuid: z.string().uuid() })
+                    const session = sessionschema.safeParse(req.session)
+                    if (!session.success) return res.send({ code: 1 })
+
+                    const bodyschema = z.object({ property: z.string().uuid(), lost: z.boolean() })
+                    const body = bodyschema.safeParse(req.body)
+                    if (!body.success) return res.send({ code: 2 })
+
+                    const resolvequery = await server.properties.resolve(session.data.uuid, body.data.property)
+                    if (resolvequery.code) return res.send({ code: 3 })
+
+                    const property = resolvequery.data
+
+                    let status = 0
+                    if (body.data.lost) {
+                        if (property.status > 1) return res.send({ code: 4 })
+                        status = property.status == 1 ? 2 : 3
+                    } else {
+                        if (property.status < 2) return res.send({ code: 4 })
+                        status = 0
+                    }
+
+                    const updatequery = await server.properties.update(session.data.uuid, body.data.property, status)
+                    if (updatequery.code) return res.send({ code: 5 })
+                    
+                    if (body.data.lost) res.send({ code: 0, reported: property.status == 1 })
+                    else res.send({ code: 0 })
+                },  
+            ]
+        })
+    ]
+});

--- a/src/routes/api/v1/property/update.endpoint.ts
+++ b/src/routes/api/v1/property/update.endpoint.ts
@@ -34,7 +34,7 @@ export default new Route({
                         status = 0
                     }
 
-                    const updatequery = await server.properties.update(session.data.uuid, body.data.property, status)
+                    const updatequery = await server.properties.update(session.data.uuid, body.data.property, status, body.data.lost ? undefined : false)
                     if (updatequery.code) return res.send({ code: 5 })
                     
                     if (body.data.lost) res.send({ code: 0, recovery: property.recovery ?? false })

--- a/src/routes/api/v1/property/update.endpoint.ts
+++ b/src/routes/api/v1/property/update.endpoint.ts
@@ -34,7 +34,7 @@ export default new Route({
                         status = 0
                     }
 
-                    const updatequery = await server.properties.update(session.data.uuid, body.data.property, status, body.data.lost ? undefined : false)
+                    const updatequery = await server.properties.update(session.data.uuid, body.data.property, status, body.data.lost ? undefined : null)
                     if (updatequery.code) return res.send({ code: 5 })
                     
                     if (body.data.lost) res.send({ code: 0, recovery: property.recovery ?? false })

--- a/src/routes/api/v1/users/resolve.endpoint.ts
+++ b/src/routes/api/v1/users/resolve.endpoint.ts
@@ -16,16 +16,13 @@ export default new Route({
                     const sessionschema = z.object({ uuid: z.string().uuid(), rank: z.number() })
                     const session = sessionschema.safeParse(req.session)
                     if (!session.success) return res.send({ code: 1 })
-
-                    let uuid = session.data.uuid
-
-                    if (session.data.rank >= Rank.ADMIN) {
-                        const bodyschema = z.object({ uuid: z.optional(z.string().uuid()) })
-                        const body = bodyschema.safeParse(req.query)
-                        if (!body.success) return res.send({ code: 2 })
                         
-                        if (body.data.uuid) uuid = body.data.uuid
-                    }
+                    const bodyschema = z.object({ uuid: z.optional(z.string().uuid()) })
+                    const body = bodyschema.safeParse(req.query)
+                    if (!body.success) return res.send({ code: 2 })
+                            
+                    let uuid = session.data.uuid
+                    if (body.data.uuid) uuid = body.data.uuid
 
                     const query = await server.users.resolve(uuid)
                     if (query.code) return res.send({ code: 3 })
@@ -36,7 +33,6 @@ export default new Route({
                         id: query.id,
                         name: query.name,
                         email: query.email,
-                        rank: query.rank,
                         created: new Date(query.created).valueOf()
                     })
                 },  


### PR DESCRIPTION
Adds property registration and recovery features.

Adds the `/api/v1/property` endpoint family.

`GET /api/v1/property/list` returns the list of the user's registered properties.
`GET /api/v1/property/resolve` requires a parameter `property` and returns the property details of property with UUID `property`.
`POST /api/v1/property/register` requires a body with parameters `name` and `description`, which registers a property with name `name` and description `description`.
`POST /api/v1/property/unregister` requires a body with parameter `property`, which unregisters a user's property with UUID `property`.
`POST /api/v1/property/update` requires a body with parameters `property` and `lost`, and marks the property with UUID `property` as lost or not lost, as per the boolean parameter `lost`. If `lost` is true, it returns recovery details `recovery`, if available, else it is returned with value null.
`POST /api/v1/property/report` requires a body with parameters `property`, `surrendered`,  optionally `message`, which marks the property with UUID `property` as found, and attaches recovery details `surrendered` and `message` for the owner to recover the item.